### PR TITLE
Remove peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you are trying to build a component that is not in Cedar, you should instead 
 
 The component variables inherit values from the design tokens, so you will need to install both packages:
 
-`npm install --save-dev @rei/cdr-tokens@1.0.0 @rei/cdr-component-variables`
+`npm install --save-dev @rei/cdr-tokens @rei/cdr-component-variables`
 
 Your project must be able to compile SCSS or LESS in order to make use of this package.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-component-variables",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -782,7 +782,6 @@
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.6.2.tgz",
       "integrity": "sha512-FX1ddj2gf7psgslvkkKeyxftnslUFDY9OHGnp+wJ+4JIKSEABB1fKVZiE7/2n+C9RVTPfPwpOqGmFf5TGvg0Bw==",
-      "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.2"
@@ -896,14 +895,12 @@
     "@rei/cdr-tokens": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-2.0.0.tgz",
-      "integrity": "sha512-d11g32YTlZFTl0yQGZmmcdiwLUoxE5KzmfHzATtyZNG6eeaKU/2E6vPUwWvwhPyxINYR25Dm/tRADIcIDNzCbg==",
-      "dev": true
+      "integrity": "sha512-d11g32YTlZFTl0yQGZmmcdiwLUoxE5KzmfHzATtyZNG6eeaKU/2E6vPUwWvwhPyxINYR25Dm/tRADIcIDNzCbg=="
     },
     "@rei/cedar": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-3.0.0.tgz",
       "integrity": "sha512-4hVGphIms53tZIoiStYS3eKJLmal7u4H95cGZ/kCuz/Krp+B/O6xxGCpAH3uViJfRkf9X9e06bGmiAREnulpEg==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "^7.5.5",
         "@babel/runtime-corejs3": "^7.5.5",
@@ -916,7 +913,6 @@
           "version": "7.6.2",
           "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.2.tgz",
           "integrity": "sha512-EXxN64agfUqqIGeEjI5dL5z0Sw0ZwWo1mLTi4mQowCZ42O59b7DRpZAnTC6OqdF28wMBMFKNb/4uFGrVaigSpg==",
-          "dev": true,
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -924,8 +920,7 @@
         "@vue/babel-helper-vue-jsx-merge-props": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
-          "integrity": "sha512-6tyf5Cqm4m6v7buITuwS+jHzPlIPxbFzEhXR5JGZpbrvOcp1hiQKckd305/3C7C36wFekNTQSxAtgeM0j0yoUw==",
-          "dev": true
+          "integrity": "sha512-6tyf5Cqm4m6v7buITuwS+jHzPlIPxbFzEhXR5JGZpbrvOcp1hiQKckd305/3C7C36wFekNTQSxAtgeM0j0yoUw=="
         }
       }
     },
@@ -2983,8 +2978,7 @@
     "clsx": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.0.4.tgz",
-      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg==",
-      "dev": true
+      "integrity": "sha512-1mQ557MIZTrL/140j+JVdRM6e31/OA4vTYxXgqIIZlndyfjHpyawKZia1Im05Vp9BWmImkcNrNtFYQMyFcgJDg=="
     },
     "co": {
       "version": "4.6.0",
@@ -3395,8 +3389,7 @@
     "core-js-pure": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.2.1.tgz",
-      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow==",
-      "dev": true
+      "integrity": "sha512-+qpvnYrsi/JDeQTArB7NnNc2VoMYLE1YSkziCDHgjexC2KH7OFiGhLUd3urxfyWmNjSwSW7NYXPWHMhuIJx9Ow=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -7562,8 +7555,7 @@
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
-      "dev": true
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
@@ -9890,8 +9882,7 @@
     "regenerator-runtime": {
       "version": "0.13.2",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.2.tgz",
-      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA==",
-      "dev": true
+      "integrity": "sha512-S/TQAZJO+D3m9xeN1WTI8dLKBBiRgXBlTJvbWjCThHWZj9EvHK70Ff50/tYj2J/fvBY6JtFVwRuazHN2E7M9BA=="
     },
     "regenerator-transform": {
       "version": "0.13.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rei/cdr-component-variables",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Style variables exported from Cedar components",
   "style": "dist/scss/index.scss",
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,13 +26,11 @@
   "homepage": "https://rei.github.io/rei-cedar-component-variables/#/",
   "author": "REI Software Engineering",
   "license": "MIT",
-  "peerDependencies": {
-    "@rei/cedar": "3.0.0",
-    "@rei/cdr-tokens": "2.0.0"
+  "dependencies": {
+    "@rei/cedar": "^3.0.0",
+    "@rei/cdr-tokens": "^2.0.0"
   },
   "devDependencies": {
-    "@rei/cdr-tokens": "^2.0.0",
-    "@rei/cedar": "^3.0.0",
     "@vue/cli-plugin-babel": "^3.4.0",
     "@vue/cli-plugin-eslint": "^3.4.0",
     "@vue/cli-service": "^3.11.0",

--- a/src/App.vue
+++ b/src/App.vue
@@ -18,10 +18,10 @@ export default {
       return packageJson.version;
     },
     tokensVersion() {
-      return packageJson.peerDependencies['@rei/cdr-tokens'];
+      return packageJson.dependencies['@rei/cdr-tokens'];
     },
     cedarVersion() {
-      return packageJson.peerDependencies['@rei/cedar'];
+      return packageJson.dependencies['@rei/cedar'];
     }
   }
 }


### PR DESCRIPTION
peerDeps doesn't make sense here because component variables don't rely on the global css to work. Also makes it more difficult for consumers to upgrade.