### PR TITLE
move cedar to a peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1064,6 +1064,7 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
       "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
+      "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -1072,6 +1073,7 @@
       "version": "7.11.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
       "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
         "regenerator-runtime": "^0.13.4"
@@ -1229,12 +1231,14 @@
     "@rei/cdr-tokens": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@rei/cdr-tokens/-/cdr-tokens-5.0.0.tgz",
-      "integrity": "sha512-j8i5odAgQi3AuBN1ujVe3X0zi+GTBsUUTXZ4VwFZO7NIuQibsRvoGrrVObCrpFIIcAJZep9K3OpvlLZ0bcyL2A=="
+      "integrity": "sha512-j8i5odAgQi3AuBN1ujVe3X0zi+GTBsUUTXZ4VwFZO7NIuQibsRvoGrrVObCrpFIIcAJZep9K3OpvlLZ0bcyL2A==",
+      "dev": true
     },
     "@rei/cedar": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@rei/cedar/-/cedar-6.0.0.tgz",
       "integrity": "sha512-45eJNP75ljSGMKgI2Go1i4o86StqneAiH7Z2n4FoKYgLlLEbYxn9j3EqXFm+kA98iKQQVcffF255U6WtH5Ndkg==",
+      "dev": true,
       "requires": {
         "@babel/runtime": "^7.11.2",
         "@babel/runtime-corejs3": "^7.11.2",
@@ -1563,7 +1567,8 @@
     "@vue/babel-helper-vue-jsx-merge-props": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@vue/babel-helper-vue-jsx-merge-props/-/babel-helper-vue-jsx-merge-props-1.0.0.tgz",
-      "integrity": "sha512-6tyf5Cqm4m6v7buITuwS+jHzPlIPxbFzEhXR5JGZpbrvOcp1hiQKckd305/3C7C36wFekNTQSxAtgeM0j0yoUw=="
+      "integrity": "sha512-6tyf5Cqm4m6v7buITuwS+jHzPlIPxbFzEhXR5JGZpbrvOcp1hiQKckd305/3C7C36wFekNTQSxAtgeM0j0yoUw==",
+      "dev": true
     },
     "@vue/babel-plugin-transform-vue-jsx": {
       "version": "1.1.2",
@@ -3895,7 +3900,8 @@
     "clsx": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "dev": true
     },
     "coa": {
       "version": "2.0.2",
@@ -4273,7 +4279,8 @@
     "core-js-pure": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -8243,7 +8250,8 @@
     "lodash-es": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
-      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
+      "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ==",
+      "dev": true
     },
     "lodash.defaultsdeep": {
       "version": "4.6.1",
@@ -10704,7 +10712,8 @@
     "regenerator-runtime": {
       "version": "0.13.7",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
-      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.14.5",
@@ -12123,7 +12132,8 @@
     "tabbable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-4.0.0.tgz",
-      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ=="
+      "integrity": "sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==",
+      "dev": true
     },
     "table": {
       "version": "5.4.6",

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
   "homepage": "https://rei.github.io/rei-cedar-component-variables/#/",
   "author": "REI Software Engineering",
   "license": "MIT",
-  "dependencies": {
+  "peerDependencies": {
     "@rei/cdr-tokens": "^5.0.0",
     "@rei/cedar": "^6.0.0"
   },
   "devDependencies": {
+    "@rei/cdr-tokens": "^5.0.0",
+    "@rei/cedar": "^6.0.0",
     "@vue/cli-plugin-babel": "^4.5.3",
     "@vue/cli-plugin-eslint": "^4.5.3",
     "@vue/cli-service": "^4.5.3",


### PR DESCRIPTION
Users have to manually load the cedar CSS reset and SCSS/LESS tokens in order for component variables to work, so these should be peers not dependencies to make that relationship clearer.

Can probably just release this as part of the fall release, we don't have enough component variables users to make this urgent

We should also add usage info to the component variables doc site page, as currently that info only appears in the readme for this repo: https://github.com/rei/rei-cedar-component-variables#usage. 

Added that to the Trello card for other component variables doc site updates: https://trello.com/c/VfNN3Qeg/840-move-component-variables-examples-into-doc-site